### PR TITLE
Change steamid description to be accurate

### DIFF
--- a/lua/xadmin/commands/misc.lua
+++ b/lua/xadmin/commands/misc.lua
@@ -25,7 +25,7 @@ end)
 --- #
 --- # STEAMID
 --- #
-xAdmin.Core.RegisterCommand("steamid", "Gets a user's SteamID32", 0, function(admin, args)
+xAdmin.Core.RegisterCommand("steamid", "Gets a user's SteamID64", 0, function(admin, args)
 	if not args or not args[1] then
 		return
 	end


### PR DESCRIPTION
Changed it from "Get a user's SteamID32" to "Get a user's SteamID64" as this is what it actually does.